### PR TITLE
Add jelly escape-by-default

### DIFF
--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <!--
   This view is used to render the installed plugins page.
 -->

--- a/src/main/resources/org/jenkinsci/plugins/favicon/FaviconPageDecorator/global.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/favicon/FaviconPageDecorator/global.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:section title="Favicon">
     <f:entry title="Favicon Path" field="faviconPath">


### PR DESCRIPTION
This caused tests to fail:

```
Failed tests: 
  JellyTestSuiteBuilder$JellyCheck.runTest:108 <?jelly escape-by-default='true'?> is missing in file:jenkins-favicon-plugin/target/classes/org/jenkinsci/plugins/favicon/FaviconPageDecorator/global.jelly
  JellyTestSuiteBuilder$JellyCheck.runTest:108 <?jelly escape-by-default='true'?> is missing in file:jenkins-favicon-plugin/target/classes/index.jelly
```
